### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,9 @@ DEPENDENCIES = [
     'coloredlogs>=8.0',
     'colorama>=0.3.9',
     'adal>=0.5.0',
-    'docker~=3.0.0',
-    'kubernetes~=7.0.0',
-    'docker~=3.0.0',
-    'aiohttp~=3.1.3',
+    'kubernetes~=7.0',
+    'docker~=3.0',
+    'aiohttp~=3.1',
 ]
 
 setup(


### PR DESCRIPTION
Update the CLI dependencies to work with Python 3.7:

In details:
- docker is twice
- `~=3.0.0` means `3.0.x`, where `~=3.0` means `3.x`. This allows us more flexibility to newer version, but following semver to be sure we are not broken by a major release. This unlocks Python 3.7 as well, since 3.0 is not compatible with 3.7 where docker 3.5 is.

I tested it with the following commands with success:
- a01 login
- a01 get runs
- a01 get run 1261
- a01 start run --email --live azureclidev.azurecr.io/azurecli-test-azure:python3.6-15501